### PR TITLE
Reset development endpoint

### DIFF
--- a/frontend/src/config/development.json
+++ b/frontend/src/config/development.json
@@ -1,3 +1,3 @@
 {
-  "PROVIDER_SOCKET": "wss://staging.hkwtf.com/socket/"
+  "PROVIDER_SOCKET": "ws://localhost:9944"
 }


### PR DESCRIPTION
The websocket provider in `development.json` was set to a server which did not respond. This PR resets it to `localhost`.

If this PR is not desired, feel free to close it :)