### PR TITLE
Only import FloatCore for no_std

### DIFF
--- a/node/runtime/src/price_fetch.rs
+++ b/node/runtime/src/price_fetch.rs
@@ -20,6 +20,7 @@ use simple_json::{ self, json::JsonValue };
 
 use runtime_io::{ self, misc::print_utf8 as print_bytes };
 use codec::{ Encode };
+#[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 use sp_runtime::{
   offchain::http,


### PR DESCRIPTION
Fixes the unused import warning for `FloatCore`

```
warning: unused import: `num_traits::float::FloatCore`
  --> runtime/src/price_fetch.rs:25:5
   |
25 | use num_traits::float::FloatCore;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```